### PR TITLE
Fix sliders blocked by swipe gesture detector

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -7,6 +7,7 @@ import {
   AppStateStatus,
   FlatList,
   Linking,
+  PanResponder,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -24,7 +25,6 @@ import DraggableFlatList, {
   RenderItemParams,
   ScaleDecorator,
 } from "react-native-draggable-flatlist";
-import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Sidebar, { InstalledApp, OverlaySettings, PillSettings } from "../modules/sidebar";
 
 type Tab = "handle" | "behavior" | "control" | "apps";
@@ -64,19 +64,19 @@ export default function Index() {
     Animated.timing(slideAnim, { toValue: 0, duration: 220, useNativeDriver: true }).start();
   }, [slideAnim]);
 
-  const swipeGesture = useMemo(() =>
-    Gesture.Pan()
-      .runOnJS(true)
-      .minPointers(1)
-      .maxPointers(1)
-      .onEnd((e) => {
+  const swipeResponder = useMemo(() =>
+    PanResponder.create({
+      // Run in bubbling phase so native components (Slider/SeekBar) can claim first.
+      onMoveShouldSetPanResponder: (_evt, gs) =>
+        Math.abs(gs.dx) > 20 && Math.abs(gs.dx) > Math.abs(gs.dy) * 1.5,
+      onPanResponderRelease: (_evt, gs) => {
+        if (Math.abs(gs.dx) < 40) return;
         const tabOrder: Tab[] = ["handle", "behavior", "control", "apps"];
-        const isHorizontal = Math.abs(e.translationX) > Math.abs(e.translationY) * 1.5;
-        if (!isHorizontal || Math.abs(e.translationX) < 40) return;
         const idx = tabOrder.indexOf(activeTabRef.current);
-        if (e.translationX < 0 && idx < tabOrder.length - 1) changeTab(tabOrder[idx + 1]);
-        else if (e.translationX > 0 && idx > 0) changeTab(tabOrder[idx - 1]);
-      }),
+        if (gs.dx < 0 && idx < tabOrder.length - 1) changeTab(tabOrder[idx + 1]);
+        else if (gs.dx > 0 && idx > 0) changeTab(tabOrder[idx - 1]);
+      },
+    }),
     [changeTab]
   );
 
@@ -281,8 +281,7 @@ export default function Index() {
         />
       </View>
 
-      <GestureDetector gesture={swipeGesture}>
-      <Animated.View style={{ flex: 1, transform: [{ translateX: slideAnim }] }}>
+      <Animated.View style={{ flex: 1, transform: [{ translateX: slideAnim }] }} {...swipeResponder.panHandlers}>
 
       {/* Handle tab */}
       <View style={{ display: activeTab === "handle" ? "flex" : "none", flex: 1 }}>
@@ -507,7 +506,6 @@ export default function Index() {
       </View>}
 
       </Animated.View>
-      </GestureDetector>
 
       {/* M3 Navigation Bar */}
       <View style={s.tabBar}>


### PR DESCRIPTION
## Summary

- Replace `GestureDetector` + `Gesture.Pan()` (RNGH) with React Native's `PanResponder` for tab swipe navigation
- `PanResponder.onMoveShouldSetPanResponder` runs in the bubbling phase, so native components like Android's `SeekBar` (used by `@react-native-community/slider`) can claim touch events first — fixing sliders that only responded to taps, not drags
- Tab swiping continues to work: responder only activates when horizontal movement is clear (>20 dp, dx/dy ratio > 1.5)

## Test plan

- [ ] Sliders in Handle tab (Position, Height, Width, Opacity) respond to drag gestures
- [ ] Sliders in Behavior tab (Sensitivity) respond to drag gestures
- [ ] Swiping left/right between tabs still works

https://claude.ai/code/session_01TJqUhwPtrzsWSEb2qnqSVf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJqUhwPtrzsWSEb2qnqSVf)_