### PR TITLE
Add opt-in floating window launch mode

### DIFF
--- a/android/app/src/main/java/com/anonymous/sidebar/SidebarModule.kt
+++ b/android/app/src/main/java/com/anonymous/sidebar/SidebarModule.kt
@@ -174,6 +174,7 @@ class SidebarModule(private val reactContext: ReactApplicationContext) :
         map.putBoolean("showAutoRotate", prefs.getBoolean(Prefs.SHOW_AUTO_ROTATE, true))
         map.putBoolean("showAutoBrightness", prefs.getBoolean(Prefs.SHOW_AUTO_BRIGHTNESS, true))
         map.putBoolean("showRingerMode", prefs.getBoolean(Prefs.SHOW_RINGER_MODE, true))
+        map.putBoolean("floatingWindow", prefs.getBoolean(Prefs.FLOATING_WINDOW, false))
         promise.resolve(map)
     }
 
@@ -189,6 +190,7 @@ class SidebarModule(private val reactContext: ReactApplicationContext) :
         if (settings.hasKey("showAutoRotate")) prefs.putBoolean(Prefs.SHOW_AUTO_ROTATE, settings.getBoolean("showAutoRotate"))
         if (settings.hasKey("showAutoBrightness")) prefs.putBoolean(Prefs.SHOW_AUTO_BRIGHTNESS, settings.getBoolean("showAutoBrightness"))
         if (settings.hasKey("showRingerMode")) prefs.putBoolean(Prefs.SHOW_RINGER_MODE, settings.getBoolean("showRingerMode"))
+        if (settings.hasKey("floatingWindow")) prefs.putBoolean(Prefs.FLOATING_WINDOW, settings.getBoolean("floatingWindow"))
         prefs.apply()
         val intent = Intent(reactContext, SidebarOverlayService::class.java)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/android/app/src/main/java/com/anonymous/sidebar/SidebarOverlayService.kt
+++ b/android/app/src/main/java/com/anonymous/sidebar/SidebarOverlayService.kt
@@ -182,7 +182,8 @@ class SidebarOverlayService : Service() {
         val showTorch: Boolean,
         val showAutoRotate: Boolean,
         val showAutoBrightness: Boolean,
-        val showRingerMode: Boolean
+        val showRingerMode: Boolean,
+        val floatingWindow: Boolean
     )
 
     private fun pillPrefs(): PillPrefs {
@@ -227,7 +228,8 @@ class SidebarOverlayService : Service() {
             p.getBoolean(Prefs.SHOW_TORCH, true),
             p.getBoolean(Prefs.SHOW_AUTO_ROTATE, true),
             p.getBoolean(Prefs.SHOW_AUTO_BRIGHTNESS, true),
-            p.getBoolean(Prefs.SHOW_RINGER_MODE, true)
+            p.getBoolean(Prefs.SHOW_RINGER_MODE, true),
+            p.getBoolean(Prefs.FLOATING_WINDOW, false)
         )
     }
 
@@ -1066,7 +1068,21 @@ class SidebarOverlayService : Service() {
         }
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         try {
-            startActivity(intent)
+            if (overlayPrefs().floatingWindow) {
+                val metrics = wm.currentWindowMetrics.bounds
+                val sw = metrics.width()
+                val sh = metrics.height()
+                val w = (sw * 0.75f).toInt()
+                val h = (sh * 0.65f).toInt()
+                val left = (sw - w) / 2
+                val top = (sh - h) / 4
+                val opts = ActivityOptions.makeBasic().apply {
+                    launchBounds = Rect(left, top, left + w, top + h)
+                }
+                startActivity(intent, opts.toBundle())
+            } else {
+                startActivity(intent)
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to launch $pkg", e)
             Handler(Looper.getMainLooper()).post {

--- a/android/app/src/main/java/com/anonymous/sidebar/SidebarPrefs.kt
+++ b/android/app/src/main/java/com/anonymous/sidebar/SidebarPrefs.kt
@@ -21,4 +21,5 @@ internal object Prefs {
     const val SHOW_AUTO_BRIGHTNESS = "show_auto_brightness"
     const val SHOW_RINGER_MODE = "show_ringer_mode"
     const val LAUNCH_TAB = "launch_tab"
+    const val FLOATING_WINDOW = "floating_window"
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -55,6 +55,7 @@ const PANEL_COLORS: { key: string }[] = [
 const DEFAULT_OVERLAY: OverlaySettings = {
   autoHideFullscreen: false, showLabels: true, vibration: true, sensitivity: 16,
   quickControlsEnabled: true, showTorch: true, showAutoRotate: true, showAutoBrightness: true, showRingerMode: true,
+  floatingWindow: false,
 };
 
 export default function Index() {
@@ -488,6 +489,18 @@ export default function Index() {
               <Switch
                 value={overlay.vibration}
                 onValueChange={v => setOverlay(p => ({ ...p, vibration: v }))}
+                trackColor={{ true: colors.tint }}
+              />
+            </View>
+            <View style={s.separator} />
+            <View style={s.row}>
+              <View style={{ flex: 1 }}>
+                <Text style={s.rowLabel}>Floating window</Text>
+                <Text style={s.rowSub}>Open apps in a floating window (requires freeform mode)</Text>
+              </View>
+              <Switch
+                value={overlay.floatingWindow}
+                onValueChange={v => setOverlay(p => ({ ...p, floatingWindow: v }))}
                 trackColor={{ true: colors.tint }}
               />
             </View>

--- a/modules/sidebar.ts
+++ b/modules/sidebar.ts
@@ -28,6 +28,7 @@ export interface OverlaySettings {
   showAutoRotate: boolean;
   showAutoBrightness: boolean;
   showRingerMode: boolean;
+  floatingWindow: boolean;
 }
 
 export default {


### PR DESCRIPTION
## Summary

- New **Floating window** toggle in the Behavior tab
- When enabled, apps are launched with `ActivityOptions.setLaunchBounds()` centred on screen at 75% width × 65% height
- On devices where freeform mode is not active, the option is silently ignored and the app opens fullscreen as usual (no crash, no harm)
- Subtitle on the toggle explains the device requirement

## How to enable freeform mode (if needed)
```
adb shell settings put global enable_freeform_support 1
```
Then reboot. Works out of the box on Samsung DeX and some OEM ROMs.

## Test plan
- [ ] Toggle off → apps open fullscreen as before
- [ ] Toggle on (freeform enabled device) → apps open as a centred floating window
- [ ] Toggle on (freeform disabled device) → apps open fullscreen, no error

https://claude.ai/code/session_01TJqUhwPtrzsWSEb2qnqSVf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJqUhwPtrzsWSEb2qnqSVf)_