### PR TITLE
Fix volume slider: add MODIFY_AUDIO_SETTINGS permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
   <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
   <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
   <uses-permission android:name="android.permission.EXPAND_STATUS_BAR"/>
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW"/>

--- a/android/app/src/main/java/com/anonymous/sidebar/SidebarOverlayService.kt
+++ b/android/app/src/main/java/com/anonymous/sidebar/SidebarOverlayService.kt
@@ -503,7 +503,10 @@ class SidebarOverlayService : Service() {
                     "🔊", am.getStreamVolume(AudioManager.STREAM_MUSIC),
                     0, am.getStreamMaxVolume(AudioManager.STREAM_MUSIC),
                     labelColor, tileActive, tileBg
-                ) { v -> runCatching { am.setStreamVolume(AudioManager.STREAM_MUSIC, v, 0) } },
+                ) { v ->
+                    try { am.setStreamVolume(AudioManager.STREAM_MUSIC, v, 0) }
+                    catch (e: Exception) { Log.w(TAG, "setStreamVolume failed", e) }
+                },
                 LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT
                 ).apply { if (oPrefs.showBrightnessSlider) topMargin = dp(6) })


### PR DESCRIPTION
## Summary

- Add `MODIFY_AUDIO_SETTINGS` permission to `AndroidManifest.xml`
- Replace silent `runCatching` on `setStreamVolume` with a logged `try/catch`

## Root cause

`AudioManager.setStreamVolume` is annotated `@RequiresPermission(MODIFY_AUDIO_SETTINGS)` and on Android 12+ the system enforces this — calls from apps without the permission throw a `SecurityException`. The exception was silently swallowed by `runCatching`, so the slider thumb moved visually but volume never changed.

`MODIFY_AUDIO_SETTINGS` is a *normal* permission (auto-granted, no user prompt required) so adding it to the manifest is all that's needed.

## Test plan
- [ ] Drag the volume slider → system media volume changes in real time
- [ ] Verify no logcat warning `setStreamVolume failed` appears during normal use
- [ ] Brightness slider still works (unrelated, but good to confirm)

https://claude.ai/code/session_01TJqUhwPtrzsWSEb2qnqSVf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJqUhwPtrzsWSEb2qnqSVf)_